### PR TITLE
Refactored AzureEmailSender to support latest stable version of Azure.Communication.Email package (v1.0.0)

### DIFF
--- a/src/Senders/FluentEmail.Azure.Email/AzureEmailSender.cs
+++ b/src/Senders/FluentEmail.Azure.Email/AzureEmailSender.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Communication.Email;
-using Azure.Communication.Email.Models;
 using Azure.Core;
 using FluentEmail.Core;
 using FluentEmail.Core.Interfaces;
@@ -19,6 +18,13 @@ namespace FluentEmail.Azure.Email;
 public class AzureEmailSender : ISender
 {
     private EmailClient _emailClient;
+
+    /// <summary>
+    /// The priority header to use when specifying the importance of an email.
+    /// Values: 1-High, 3-Normal (default), 5-Low
+    /// https://sendgrid.com/blog/magic-email-headers/
+    /// </summary>
+    const string PriorityHeader = "X-Priority";
 
     /// <summary>
     /// Initializes a new instance of <see cref="AzureEmailSender"/>
@@ -99,7 +105,7 @@ public class AzureEmailSender : ISender
         // Azure Email Sender doesn't allow us to specify the 'from' display name (instead the sender name is defined in the blade configuration)
         // var sender = $"{email.Data.FromAddress.Name} <{email.Data.FromAddress.EmailAddress}>";
         var sender = email.Data.FromAddress.EmailAddress;
-        var emailMessage = new EmailMessage(sender, emailContent, emailRecipients);
+        var emailMessage = new EmailMessage(sender, emailRecipients, emailContent);
         
         if (email.Data.ReplyToAddresses.Any(a => !string.IsNullOrWhiteSpace(a.EmailAddress)))
         {
@@ -113,7 +119,7 @@ public class AzureEmailSender : ISender
         {
             foreach (var header in email.Data.Headers)
             {
-                emailMessage.CustomHeaders.Add(new EmailCustomHeader(header.Key, header.Value));
+                emailMessage.Headers.Add(header.Key, header.Value);
             }
         }
 
@@ -125,19 +131,19 @@ public class AzureEmailSender : ISender
             }
         }
 
-        emailMessage.Importance = email.Data.Priority switch
+        emailMessage.Headers.Add(PriorityHeader, (email.Data.Priority switch
         {
-            Priority.High => EmailImportance.High,
-            Priority.Normal => EmailImportance.Normal,
-            Priority.Low => EmailImportance.Low,
-            _ => EmailImportance.Normal
-        };
+            Priority.High => 1,
+            Priority.Normal => 3,
+            Priority.Low => 5,
+            _ => 3
+        }).ToString());
+
 
         try
         {
-            var sendEmailResult = (await _emailClient.SendAsync(emailMessage, token ?? CancellationToken.None)).Value;
-            
-            var messageId = sendEmailResult.MessageId;
+            EmailSendOperation sendOperation = await _emailClient.SendAsync(WaitUntil.Started, emailMessage, token ?? CancellationToken.None);
+            var messageId = sendOperation.Id;
             if (string.IsNullOrWhiteSpace(messageId))
             {
                 return new SendResponse
@@ -149,32 +155,21 @@ public class AzureEmailSender : ISender
             // We want to verify that the email was sent.
             // The maximum time we will wait for the message status to be sent/delivered is 2 minutes.
             var cancellationToken = new CancellationTokenSource(TimeSpan.FromMinutes(2));
-            SendStatusResult sendStatusResult;
-            do
-            {
-                sendStatusResult = await _emailClient.GetSendStatusAsync(messageId, cancellationToken.Token);
-                
-                if (sendStatusResult.Status != SendStatus.Queued)
-                {
-                    break;
-                }
+            var sendStatusResult = sendOperation.WaitForCompletion(cancellationToken.Token).Value;
 
-                await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken.Token);
-            } while (!cancellationToken.IsCancellationRequested);
+            if (sendStatusResult.Status == EmailSendStatus.Succeeded)
+            {
+                return new SendResponse
+                {
+                    MessageId = messageId
+                };
+            }
 
             if (cancellationToken.IsCancellationRequested)
             {
                 return new SendResponse
                 {
                     ErrorMessages = new List<string> { "Failed to send email, timed out while getting status." }
-                };
-            }
-
-            if (sendStatusResult.Status == SendStatus.OutForDelivery)
-            {
-                return new SendResponse
-                {
-                    MessageId = messageId
                 };
             }
             
@@ -191,17 +186,7 @@ public class AzureEmailSender : ISender
             };
         }
     }
-    
-    private async Task<EmailAttachment> ConvertAttachment(Attachment attachment) =>
-        new(attachment.Filename, attachment.ContentType,
-            await GetAttachmentAsBase64String(attachment.Data));
 
-    private async Task<string> GetAttachmentAsBase64String(Stream stream)
-    {
-        using var ms = new MemoryStream();
-        
-        await stream.CopyToAsync(ms);
-        
-        return Convert.ToBase64String(ms.ToArray());
-    }
+    private async Task<EmailAttachment> ConvertAttachment(Attachment attachment) =>
+        new(attachment.Filename, attachment.ContentType, await BinaryData.FromStreamAsync(attachment.Data));
 }

--- a/src/Senders/FluentEmail.Azure.Email/AzureEmailSender.cs
+++ b/src/Senders/FluentEmail.Azure.Email/AzureEmailSender.cs
@@ -96,7 +96,9 @@ public class AzureEmailSender : ISender
         
         var emailRecipients = new EmailRecipients(toRecipients, ccRecipients, bccRecipients);
 
-        var sender = $"{email.Data.FromAddress.Name} <{email.Data.FromAddress.EmailAddress}>";
+        // Azure Email Sender doesn't allow us to specify the 'from' display name (instead the sender name is defined in the blade configuration)
+        // var sender = $"{email.Data.FromAddress.Name} <{email.Data.FromAddress.EmailAddress}>";
+        var sender = email.Data.FromAddress.EmailAddress;
         var emailMessage = new EmailMessage(sender, emailContent, emailRecipients);
         
         if (email.Data.ReplyToAddresses.Any(a => !string.IsNullOrWhiteSpace(a.EmailAddress)))

--- a/src/Senders/FluentEmail.Azure.Email/FluentEmail.Azure.Email.csproj
+++ b/src/Senders/FluentEmail.Azure.Email/FluentEmail.Azure.Email.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Communication.Email" Version="1.0.0-beta.1" />
+      <PackageReference Include="Azure.Communication.Email" Version="1.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Senders/FluentEmail.Azure.Email/FluentEmailAzureEmailBuilderExtensions.cs
+++ b/src/Senders/FluentEmail.Azure.Email/FluentEmailAzureEmailBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
             this FluentEmailServicesBuilder builder,
             string connectionString)
         {
-            builder.Services.TryAdd(ServiceDescriptor.Scoped<ISender>(_ => new AzureEmailSender(connectionString)));
+            builder.Services.TryAdd(ServiceDescriptor.Singleton((IServiceProvider x) => (ISender)(object)new AzureEmailSender(connectionString)));
             return builder;
         }
         
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
             string connectionString,
             EmailClientOptions options)
         {
-            builder.Services.TryAdd(ServiceDescriptor.Scoped<ISender>(_ => new AzureEmailSender(connectionString, options)));
+            builder.Services.TryAdd(ServiceDescriptor.Singleton((IServiceProvider x) => (ISender)(object)new AzureEmailSender(connectionString, options)));
             return builder;
         }
         
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.DependencyInjection
             AzureKeyCredential keyCredential,
             EmailClientOptions options = default)
         {
-            builder.Services.TryAdd(ServiceDescriptor.Scoped<ISender>(_ => new AzureEmailSender(endpoint, keyCredential, options)));
+            builder.Services.TryAdd(ServiceDescriptor.Singleton((IServiceProvider x) => (ISender)(object)new AzureEmailSender(endpoint, keyCredential, options)));
             return builder;
         }
         
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.DependencyInjection
             TokenCredential tokenCredential,
             EmailClientOptions options = default)
         {
-            builder.Services.TryAdd(ServiceDescriptor.Scoped<ISender>(_ => new AzureEmailSender(endpoint, tokenCredential, options)));
+            builder.Services.TryAdd(ServiceDescriptor.Singleton((IServiceProvider x) => (ISender)(object)new AzureEmailSender(endpoint, tokenCredential, options)));
             return builder;
         }
     }


### PR DESCRIPTION
Removed sender name from the email send request (Azure uses the DisplayName associated with the MailFrom address instead)
Replaced scoped AzureEmailSender with singleton registration

Azure was rejecting email requests with a sender name specified in the request (even if it matched the MailFrom DisplayName precisely)
